### PR TITLE
[e2etests] Add game_log command

### DIFF
--- a/bin/solitaire.cpp
+++ b/bin/solitaire.cpp
@@ -22,6 +22,8 @@ DEFINE_bool(autoreveal, true, "Newly revealed cards will be flipped for the play
 DEFINE_bool(autosolve, true, "Once all cards are revealed, the game will auto-solve itself for the player");
 DEFINE_bool(recycle_penalty, false, "-100 pts for each full cycle through the stock");
 
+vector<string> game_log;
+
 const string program_help() {
   string helpstr;
   helpstr += "command help for ./solitaire:\n";
@@ -36,6 +38,7 @@ string game_help() {
   helpstr += "game help for solitaire:\n";
   helpstr += "* x, exit: quit the game\n";
   helpstr += "* h, help: print this help\n";
+  helpstr += "* l, log: print out all commands you've given so far\n";
   helpstr += "* r, restart: restart and deal a new game\n";
   helpstr += "* t, toggle: toggle board labels\n";
   helpstr += "* b, board: print the board\n";
@@ -61,6 +64,8 @@ string get_cmd() {
 bool is_not_exit(string str) { return (str != "exit" && str != "x"); }
 
 bool is_help(string str) { return (str == "help" || str == "h"); }
+
+bool is_gamelog(string str) { return (str == "log" || str == "l"); }
 
 bool is_restart(string str) { return (str == "restart" || str == "r"); }
 
@@ -99,6 +104,11 @@ int play(mt19937 generator) {
   while (!cin.eof() && is_not_exit(cmd)) {
     if (is_help(cmd)) {
       cout << game_help() << endl;
+    } else if (is_gamelog(cmd)) {
+      cout << "Game log thus far:\n";
+      for (auto line : game_log) {
+        cout << line << "\n";
+      }
     } else if (is_restart(cmd)) {
       cout << "Restarting the game." << endl;
       b = new_game(generator);
@@ -133,6 +143,7 @@ int play(mt19937 generator) {
     }
 
     cmd = get_cmd();
+    game_log.push_back(cmd);
   }
   return b.getScore();
 }


### PR DESCRIPTION
Honestly much easier than I thought.

The only thing about it is that it really points out to me how coupled everything is to the main/board - the commands themselves don't do barely anything at all. -_-

Example output - not thoroughly tested, so don't mind me:

```
kelly:my_very_good_klondike./solitaire play 2
Welcome to the game! (h=help, x=exit)
cmd:
( - ) ( - ) ( - ) ( - )   <5♠>  |Score: 0|
[2♦]
[X][9♦]
[X][X][10♦]
[X][X][X][2♣]
[X][X][X][X][7♦]
[X][X][X][X][X][K♠]
[X][X][X][X][X][X][4♥]
cmd: h
game help for solitaire:
* x, exit: quit the game
* h, help: print this help
* l, log: print out all commands you've given so far
* r, restart: restart and deal a new game
* t, toggle: toggle board labels
* b, board: print the board
* n, next: go to next card in stock
* i, hint: print a possible move. cycles through possible moves   
* score: print current score
* solve: solve the current game, if all cards have been revealed  
* m, move: move <s><#> <d> - attempt to move # cards from s to d  
  from stock or fdn, do not provide a count. from pile, please do.
  eg. m p2 3 p1; m s f3; m f1 p4; m s p7
cmd: l
Game log thus far:
h
l
cmd: x
```

Part of issue #30 