### PR TITLE
[CI] Reduce latency thresholds - cut them in half, 120->60, 10->5

### DIFF
--- a/full_solve_tests.sh
+++ b/full_solve_tests.sh
@@ -2,8 +2,8 @@
 # kill the process if it doesn't finish within 1 s - usually i see ~0.4s
 # Above is no longer true since the implementation of the hint command.
 # set -x
-DBG_TIMEOUT_LIMIT=120
-OPT_TIMEOUT_LIMIT=10
+DBG_TIMEOUT_LIMIT=60
+OPT_TIMEOUT_LIMIT=5
 
 TOTAL_CORRECTNESS_RESULT=0
 TOTAL_TIMEOUT_RESULT=0


### PR DESCRIPTION
I made two significant changes -
1. No isStuck() calls on next() moves (only update isStuck/possible moves for actual moves)
2. 2 filters on isLegal pre-filter rather than post-filter - first, ignoring moves to foundations with size >1, and ignoring moves between foundations.

If CI can handle these thresholds, that's awesome.